### PR TITLE
Added capable regex stubs

### DIFF
--- a/t/10_global.t
+++ b/t/10_global.t
@@ -22,7 +22,16 @@ is status(lwp, $httpd->endpoint) => 404, 'returns a stub response';
 Test::Mock::LWP::Conditional->stub_request(
     $httpd->endpoint => sub { res(500) }
 );
-is status(lwp, $httpd->endpoint) => 500, 'returns a code stubed response';
+is status(lwp, $httpd->endpoint) => 500, 'returns a code stubbed response';
+
+my $url = $httpd->endpoint;
+my $regex = qr!$url/foo/ba[rz]/!;
+Test::Mock::LWP::Conditional->stub_request(
+    $regex => sub { res(500) }
+);
+is status(lwp, "$url/foo/bar/") => 500, 'returns a code stubbed response';
+is status(lwp, "$url/foo/baz/") => 500, 'returns a code stubbed response';
+
 
 done_testing;
 

--- a/t/11_per_instance.t
+++ b/t/11_per_instance.t
@@ -21,5 +21,15 @@ is status($ua, $httpd->endpoint) => 404, 'returns a stub response';
 my $new_ua = lwp;
 is status($new_ua, $httpd->endpoint) => 204, 'another instance returns a real response';
 
+my $another_ua = lwp;
+my $url = $httpd->endpoint;
+my $regex = qr!$url/foo/ba[rz]/!;
+is status($another_ua, $url) => 204, 'returns a real response';
+
+$another_ua->stub_request($regex => res(404));
+is status($another_ua, "$url/foo/bar/") => 404, 'returns a stub response';
+is status($another_ua, "$url/foo/baz/") => 404, 'returns a stub response';
+is status($another_ua, "$url/foo/bee/") => 204, 'returns a real response';
+
 done_testing;
 


### PR DESCRIPTION
### Specify Regex URLs for mock responses

Works for global and lexical use cases


```perl
my $regex_uri = qr!http://example\.com/foo/ba[rz]/!;

# global
Test::Mock::LWP::Conditional->stub_request($regex_uri => HTTP::Response->new(503));
is LWP::UserAgent->new->get("http://example.com/foo/bar/")->code => 503;
is LWP::UserAgent->new->get("http://example.com/foo/baz/")->code => 503;
 
# lexical
my $ua = LWP::UserAgent->new;
$ua->stub_request($regex_uri => sub { HTTP::Response->new(500) });
is $ua->get("http://example.com/foo/bar/")->code => 500;
is LWP::UserAgent->new->get("http://example.com/foo/bar/")->code => 503;
```